### PR TITLE
Change config & Dockerfile to use Dogecoin software

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,22 +19,18 @@ RUN mkdir -p /app \
   && chown -R nobody:nogroup /app
 WORKDIR /app
 
-# Source: https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#ubuntu--debian
-RUN apt-get update && apt-get install -y make gcc g++ autoconf autotools-dev bsdmainutils build-essential git libboost-all-dev \
-  libcurl4-openssl-dev libdb++-dev libevent-dev libssl-dev libtool pkg-config python python-pip libzmq3-dev wget
+# Source: https://github.com/dogecoin/dogecoin/blob/master/doc/build-unix.md#ubuntu--debian
+RUN apt-get update && apt-get install -y python python-pip wget
 
-# VERSION: Bitcoin Core 0.20.1
-RUN git clone https://github.com/bitcoin/bitcoin \
-  && cd bitcoin \
-  && git checkout 7ff64311bee570874c4f0dfa18f518552188df08
-
-RUN cd bitcoin \
-  && ./autogen.sh \
-  && ./configure --disable-tests --without-miniupnpc --without-gui --with-incompatible-bdb --disable-hardening --disable-zmq --disable-bench --disable-wallet \
-  && make
-
-RUN mv bitcoin/src/bitcoind /app/bitcoind \
-  && rm -rf bitcoin
+# VERSION: Dogecoin Core 1.14.3 (64 bit)
+# Fetch and verify source
+RUN wget 'https://github.com/dogecoin/dogecoin/releases/download/v1.14.3/dogecoin-1.14.3-x86_64-linux-gnu.tar.gz' \
+  && echo 'a95cc29ac3c19a450e9083cc3ac24b6f61763d3ed1563bfc3ea9afbf0a2804fd dogecoin-1.14.3-x86_64-linux-gnu.tar.gz' | sha256sum -c \
+  # -> dogecoin-1.14.3-x86_64-linux-gnu.tar.gz: OK
+  && tar -xzvf dogecoin-1.14.3-x86_64-linux-gnu.tar.gz \
+  && mv dogecoin-1.14.3/bin/dogecoind /app/dogecoind \
+  && rm -rf dogecoin-1.14.3-x86_64-linux-gnu.tar.gz \
+  && rm -rf dogecoin-1.14.3
 
 # Build Rosetta Server Components
 FROM ubuntu:18.04 as rosetta-builder
@@ -62,7 +58,7 @@ COPY . src
 RUN cd src \
   && go build \
   && cd .. \
-  && mv src/rosetta-bitcoin /app/rosetta-bitcoin \
+  && mv src/rosetta-dogecoin /app/rosetta-dogecoin \
   && mv src/assets/* /app \
   && rm -rf src 
 
@@ -70,7 +66,7 @@ RUN cd src \
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev && \
+  apt-get install --no-install-recommends -y libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir -p /app \
@@ -81,7 +77,7 @@ RUN mkdir -p /app \
 WORKDIR /app
 
 # Copy binary from bitcoind-builder
-COPY --from=bitcoind-builder /app/bitcoind /app/bitcoind
+COPY --from=bitcoind-builder /app/dogecoind /app/dogecoind
 
 # Copy binary from rosetta-builder
 COPY --from=rosetta-builder /app/* /app/
@@ -89,4 +85,4 @@ COPY --from=rosetta-builder /app/* /app/
 # Set permissions for everything added to /app
 RUN chmod -R 755 /app/*
 
-CMD ["/app/rosetta-bitcoin"]
+CMD ["/app/rosetta-dogecoin"]


### PR DESCRIPTION
Fixes # .

Instead of building from source added extraction of dogecoind from dogecoin-1.14.3-x86_64-linux-gnu.tar.gz to app/rosetta-dogecoin.
