### PR TITLE
Remove license checks on CI and in makefiles.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,6 @@ jobs:
       run: |
         ! go run golang.org/x/tools/cmd/goimports -l . | read
 
-  license:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.15'
-    - uses: actions/checkout@v2
-    - name: Check license
-      run: go run github.com/google/addlicense -c "Coinbase, Inc." -l "apache" -v -check .
-
   salus:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 .PHONY: deps build run lint mocks run-mainnet-online run-mainnet-offline run-testnet-online \
-	run-testnet-offline check-comments add-license check-license shorten-lines test \
+	run-testnet-offline check-comments shorten-lines test \
 	coverage spellcheck salus build-local coverage-local format check-format
 
-ADDLICENSE_CMD=go run github.com/google/addlicense
-ADDLICENCE_SCRIPT=${ADDLICENSE_CMD} -c "Coinbase, Inc." -l "apache" -v
 SPELLCHECK_CMD=go run github.com/client9/misspell/cmd/misspell
 GOLINES_CMD=go run github.com/segmentio/golines
 GOLINT_CMD=go run golang.org/x/lint/golint
@@ -51,12 +49,6 @@ check-comments:
 lint: | check-comments
 	golangci-lint run --timeout 2m0s -v -E ${LINT_SETTINGS},gomnd
 
-add-license:
-	${ADDLICENCE_SCRIPT} .
-
-check-license:
-	${ADDLICENCE_SCRIPT} -check .
-
 shorten-lines:
 	${GOLINES_CMD} -w --shorten-comments ${GO_FOLDERS} .
 
@@ -87,4 +79,3 @@ mocks:
 	rm -rf mocks;
 	mockery --dir indexer --all --case underscore --outpkg indexer --output mocks/indexer;
 	mockery --dir services --all --case underscore --outpkg services --output mocks/services;
-	${ADDLICENCE_SCRIPT} .;


### PR DESCRIPTION
### Motivation

Currently we are forced by these checks to assign all copyright to Coinbase, which is incorrect. 

### Solution

1. Disable the checks - with this PR.
2. On files that are edited, add a line: `Copyright 2021 - Rosetta Dogecoin Developers` under the Coinbase one.
3. On fully new files that do not clone any code from elsewhere, simply assign the copyright to Rosetta Dogecoin Developers.

