### PR TITLE
[CI] upgrade-go 1.15 -> 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
     - name: Run golint
       run: |
@@ -71,7 +71,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
     - name: Check formatting
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl make gcc g++
 ENV GOLANG_VERSION 1.16.2
-ENV GOLANG_DOWNLOAD_SHA256 9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ENV GOLANG_DOWNLOAD_SHA256 951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN mkdir -p /app \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl make gcc g++
-ENV GOLANG_VERSION 1.16.2
-ENV GOLANG_DOWNLOAD_SHA256 951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_VERSION "1.16.3"
+ENV GOLANG_DOWNLOAD_SHA256 "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
+ENV GOLANG_DOWNLOAD_URL "https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && echo "$GOLANG_DOWNLOAD_SHA256 golang.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /app \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl make gcc g++
-ENV GOLANG_VERSION 1.15.5
+ENV GOLANG_VERSION 1.16.2
 ENV GOLANG_DOWNLOAD_SHA256 9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 


### PR DESCRIPTION
Tiny PR to resolve #38

It upgrades the version of Go used by our CI tools from `v1.15` to the recommended `v1.16`.

### Motivation
The rosetta-specification & this repository's readme both state dependency on a `v1.16` release of Go; our CI workflow is using `v1.15`.

### Solution
Upgrade the version of Go defined in [.github/workflows/ci.yaml](https://github.com/rosetta-dogecoin/rosetta-dogecoin/blob/main/.github/workflows/ci.yml) from `v1.15` to the recommended `v1.16`.

### Testing
Ran the changes in development branch; verified that the tests are executing & failures are expected per state of implementation. ([CI run](https://github.com/solo-fish/rosetta-dogecoin/runs/2434554304?check_suite_focus=true))

### Open questions
Could we depend on some CI workflows controlled by a `rosetta` impl or spec? Potentially one-less maintenance requirement. 