### PR TITLE
[CI] Align Makefile and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ name: CI
 
 on: [push, pull_request]
 
-env:
-  GO_PACKAGES: ./services/... ./indexer/... ./bitcoin/... ./dogecoin/...
-  GOLANGCI_LINT_VERSION: v1.32.2
-  GOLANGCI_LINT_SETTINGS: golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -57,14 +52,8 @@ jobs:
       with:
         go-version: '1.15'
     - uses: actions/checkout@v2
-    - name: Run golint
-      run: |
-        export GO_FOLDERS=$(shell echo ${{ env.GO_PACKAGES }} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
-        go run golang.org/x/lint/golint -set_exit_status ${GO_FOLDERS} .
     - name: Run golangci-lint
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ env.GOLANGCI_LINT_VERSION }}
-        golangci-lint run --timeout 2m0s -v -E ${{ env.GOLANGCI_LINT_SETTINGS }},gomnd
+      run: make lint
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run tests
-      run: go test ${{ env.GO_PACKAGES }}
+      run: make test
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
 
#41 `make lint` is failing and our CI pipeline isn't picking it up. 

```
dogecoin/genesis.go:15:1: package comment should be of the form "Package dogecoin ..."
dogecoin/params.go:15:1: package comment should be of the form "Package dogecoin ..."
```

- - -

This PR isn't to fix the linting issues, rather, the underlying problem that allowed them to sneak through our CI pipeline in the first place. 

Currently, the `make lint` and  `make test` definitions are being explicitly (redundantly) redefined in `ci.yml`. I could totally just be missing some context but this doesn't seem like the greatest practice and it's the root cause of #41 sneaking into main unnoticed.

This means that folks need to reflect their changes to `Makefile` identically in `ci.yml` or we run the risk of this situation happening again.

So the goal of this PR is to align our `Makefile` and `ci.yml` targets so we can prevent potential confusion in the event of a change to `make test/lint` while highlighting the existing linting issues that are currently going on in main.

### Solution
Change `ci.yml` use `make test` and `make lint`
