### PR TITLE
[CI] Bring back installation of golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  GOLANGCI_LINT_VERSION: v1.32.2
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -53,7 +56,9 @@ jobs:
         go-version: '1.15'
     - uses: actions/checkout@v2
     - name: Run golangci-lint
-      run: make lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ env.GOLANGCI_LINT_VERSION }}
+        make lint
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

#42 removed installation of `golangci-lint`, but the same dependency is needed for `make lint`.   

### Solution

Bring back the install script