### PR TITLE
Client test

### DIFF
--- a/bitcoin/types.go
+++ b/bitcoin/types.go
@@ -16,6 +16,7 @@
 package bitcoin
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -177,8 +178,8 @@ type PeerInfo struct {
 	SyncedHeaders  int64  `json:"synced_headers"`
 }
 
-// Block is a raw Bitcoin block (with verbosity == 2).
-type Block struct {
+// BlockJSON is a raw Bitcoin block (with verbosity == 1).
+type BlockJSON struct {
 	Hash              string  `json:"hash"`
 	Height            int64   `json:"height"`
 	PreviousBlockHash string  `json:"previousblockhash"`
@@ -192,25 +193,61 @@ type Block struct {
 	Bits              string  `json:"bits"`
 	Difficulty        float64 `json:"difficulty"`
 
-	Txs []*Transaction `json:"tx"`
+	Txs []interface{} `json:"tx"`
 }
 
-// BlockV1 is a raw Bitcoin block (with verbosity == 1).
-type BlockV1 struct {
-	Hash              string  `json:"hash"`
-	Height            int64   `json:"height"`
-	PreviousBlockHash string  `json:"previousblockhash"`
-	Time              int64   `json:"time"`
-	MedianTime        int64   `json:"mediantime"`
-	Nonce             int64   `json:"nonce"`
-	MerkleRoot        string  `json:"merkleroot"`
-	Version           int32   `json:"version"`
-	Size              int64   `json:"size"`
-	Weight            int64   `json:"weight"`
-	Bits              string  `json:"bits"`
-	Difficulty        float64 `json:"difficulty"`
+// Block is a raw Bitcoin block (with verbosity == 1).
+type Block struct {
+	Hash              string
+	Height            int64
+	PreviousBlockHash string
+	Time              int64
+	MedianTime        int64
+	Nonce             int64
+	MerkleRoot        string
+	Version           int32
+	Size              int64
+	Weight            int64
+	Bits              string
+	Difficulty        float64
 
-	Txs []string `json:"tx"`
+	Txs []*Transaction
+}
+
+// UnmarshalJSON block data to determine txs type
+func (b *Block) UnmarshalJSON(data []byte) error {
+	var res BlockJSON
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil
+	}
+
+	b.Hash = res.Hash
+	b.Height = res.Height
+	b.PreviousBlockHash = res.PreviousBlockHash
+	b.Time = res.Time
+	b.MedianTime = res.MedianTime
+	b.Nonce = res.Nonce
+	b.MerkleRoot = res.MerkleRoot
+	b.Version = res.Version
+	b.Size = res.Size
+	b.Weight = res.Weight
+	b.Bits = res.Bits
+	b.Difficulty = res.Difficulty
+
+	var txs []*Transaction
+	switch res.Txs[0].(type) {
+	case string:
+	case interface{}:
+		enc, err := json.Marshal(res.Txs)
+		if err != nil {
+			return nil
+		}
+		if err := json.Unmarshal(enc, &txs); err != nil {
+			return err
+		}
+	}
+	b.Txs = txs
+	return nil
 }
 
 // Metadata returns the metadata for a block.
@@ -359,13 +396,13 @@ type responseError struct {
 	Message string `json:"message"`
 }
 
-// blockResponseV0 is the response body for `getblock` requests (with verbosity == 0)
-type blockResponseV0 struct {
+// stringResponse is the response body for requests (with verbosity == 0)
+type stringResponse struct {
 	Result string         `json:"result"`
 	Error  *responseError `json:"error"`
 }
 
-func (b blockResponseV0) Err() error {
+func (b stringResponse) Err() error {
 	if b.Error == nil {
 		return nil
 	}
@@ -382,13 +419,13 @@ func (b blockResponseV0) Err() error {
 	)
 }
 
-// blockResponseV1 is the response body for `getblock` requests (verbosity == 1)
-type blockResponseV1 struct {
-	Result *BlockV1       `json:"result"`
+// blockResponse is the response body for `getblock` requests (verbosity == 1)
+type blockResponse struct {
+	Result *Block         `json:"result"`
 	Error  *responseError `json:"error"`
 }
 
-func (b blockResponseV1) Err() error {
+func (b blockResponse) Err() error {
 	if b.Error == nil {
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.13
 require (
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/coinbase/rosetta-bitcoin v0.0.9
 	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/tools v0.0.0-20200904185747-39188db58858 // indirect
+	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coinbase/rosetta-bitcoin v0.0.9 h1:kcVVbCS0HuvMQ4KPsfpjJyvV0fQoLL64rdAtXZ2JM00=
-github.com/coinbase/rosetta-bitcoin v0.0.9/go.mod h1:WhZEwCZ527mJjEYv1m80cyfQJU1R6Fi5i0mdx07KC+Q=
 github.com/coinbase/rosetta-sdk-go v0.6.5 h1:RytFDCPXS64vEYwIOsxsoQGlZZyP9RQvzyYikxymI4w=
 github.com/coinbase/rosetta-sdk-go v0.6.5/go.mod h1:MvQfsL2KlJ5786OdDviRIJE3agui2YcvS1CaQPDl1Yo=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Fixes # .

### Motivation
Broken tests

### Solution
Refactor BlockV1 BlockV0 to use Block with custom unmarshal function for *blockResponse in order to differentiate between blocks in client_fixtures that are prepopulated with []*Transaction and blocks that fetched from dogecoind which contain a []string for `json:"tx"`.  Also changed blockResponseV0 to stringResponse so it can be representative for any response requiring a string response.

Add if then to getBlock to determine whether method is being used for testing.

Fix construction_service_test.go by adding wallet addresses and affiliated data the app is looking for.  Made possible by @incognitojam after the merge of #32 

### Open questions
To be sure I could pass tests, I ended up omitting my custom dogecoin data since it's not necessary to prove the application is working.