### PR TITLE
adds array size check re #49

### DIFF
--- a/bitcoin/types.go
+++ b/bitcoin/types.go
@@ -235,6 +235,10 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 	b.Difficulty = res.Difficulty
 
 	var txs []*Transaction
+	if len(res.Txs) < 1 {
+		return fmt.Errorf("expected >= 1 transactions in block, got %d", len(res.Txs))
+	}
+
 	switch res.Txs[0].(type) {
 	case string:
 	case interface{}:
@@ -246,6 +250,7 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
+
 	b.Txs = txs
 	return nil
 }


### PR DESCRIPTION
Fixes #49 

### Motivation
Ensure res.Txs[0] != nil.

### Solution
Add check to make sure res.Txs[0] != nil
