### PR TITLE
[CI] upgrade go v1.15 -> v1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
     - name: Run golangci-lint
       run: |
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v2
     - name: Check formatting
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN mkdir -p /app \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl make gcc g++
-ENV GOLANG_VERSION 1.15.5
-ENV GOLANG_DOWNLOAD_SHA256 9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_VERSION "1.16.3"
+ENV GOLANG_DOWNLOAD_SHA256 "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2"
+ENV GOLANG_DOWNLOAD_URL "https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && echo "$GOLANG_DOWNLOAD_SHA256 golang.tar.gz" | sha256sum -c - \

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ However, if you prefer not to use Docker during development in your own fork (e.
 
 #### Dependencies
 
-Download and install the latest (current **1.16.2**) version of Go.
+Download and install the latest (current **1.16.3**) version of Go.
 
 https://golang.org/doc/install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rosetta-dogecoin/rosetta-dogecoin
 
-go 1.13
+go 1.16
 
 require (
 	github.com/btcsuite/btcd v0.21.0-beta


### PR DESCRIPTION
Tiny PR to resolve #38

It upgrades the version of Go used by our CI tools from `v1.15` to the recommended `v1.16`.

### Motivation
The rosetta-specification & this repository's readme both state dependency on a `v1.16` release of Go; our CI workflow is using `v1.15`.

### Solution
Upgrade the version of Go defined in [.github/workflows/ci.yaml](https://github.com/rosetta-dogecoin/rosetta-dogecoin/blob/main/.github/workflows/ci.yml) from `v1.15` to the recommended `v1.16`.

### Testing
Ran the changes in development branch; verified that the tests are executing & failures are expected per state of implementation. ([CI run](https://github.com/solo-fish/rosetta-dogecoin/runs/2434554304?check_suite_focus=true))

### Open questions
Could we depend on some CI workflows controlled by a `rosetta` impl or spec? Potentially one-less maintenance requirement. 